### PR TITLE
Adding Mangler.pyc to .gitignore, adding defaults for args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ packages/*
 .tags1
 .gan
 deployment-config.json
+
+# Compiled
+Mangler.pyc

--- a/PersonalDictionary.py
+++ b/PersonalDictionary.py
@@ -36,19 +36,19 @@ def main():
         description="Generate a dictionary list as a text file using " +
                     "permutations of terms.\nData imported from populated " +
                     "JSON template.\n\n")
-    parser.add_argument('--min', type=int, required=True,
+    parser.add_argument('--min', type=int, required=False,
                         help='Minimum password length')
-    parser.add_argument('--max', type=int, required=True,
+    parser.add_argument('--max', type=int, required=False,
                         help='Maximum password length')
-    parser.add_argument('-n', '--num', type=int, required=True,
+    parser.add_argument('-n', '--num', type=int, required=False,
                         help='Number of passwords to be generated')
-    parser.add_argument('-f', '--file', required=True, help='Criteria file')
+    parser.add_argument('-f', '--file', required=True, help='Criteria file (JSON)')
     parser.add_argument('-o', '--out', help='Generated password file')
     args = parser.parse_args()
-    min_length = args.min
-    max_length = args.max
-    password_count = args.num
-    output_file = args.out if args.out else "dictionary.txt"
+    min_length = args.min or 3
+    max_length = args.max or 12
+    password_count = args.num or 20000
+    output_file = args.out or "dictionary.txt"
 
     try:
         criteria = json.loads("".join(open(args.file, "r").readlines()))


### PR DESCRIPTION
Love this thing! When I first tried to use it, I had a few issues from a UX standpoint. I just wanted to address some of those.

There wasn't a very good error message when trying to load the criteria file, so I wanted to clarify that it must be a json file
I wanted a quick and dirty list when I first ran it and I kept running into required args, I threw a few defaults in.. min: 3, max: 12, num: 20,000
Also changed the conditional just slightly for the default dictionary file to make the line simpler

Feel free to trash this if it's not a direction you wanted to go - great tool, man!